### PR TITLE
Use existing indexes

### DIFF
--- a/benchmark/Dockerfile.ecp
+++ b/benchmark/Dockerfile.ecp
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y cmake
 # Clone project
 RUN git clone https://github.com/jgoed/big-ecp.git
 WORKDIR "/home/app/big-ecp"
-RUN git checkout use_existing_indexes
+# RUN git checkout <BRANCH>
 WORKDIR "/home/app/big-ecp/scripts"
 RUN ./gen_wrapper.sh
 RUN mv "/home/app/big-ecp/build/swig/_ecp_wrapper.so" "/home/app/"

--- a/benchmark/Dockerfile.ecp
+++ b/benchmark/Dockerfile.ecp
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y cmake
 # Clone project
 RUN git clone https://github.com/jgoed/big-ecp.git
 WORKDIR "/home/app/big-ecp"
-# RUN git checkout <BRANCH>
+RUN git checkout use_existing_indexes
 WORKDIR "/home/app/big-ecp/scripts"
 RUN ./gen_wrapper.sh
 RUN mv "/home/app/big-ecp/build/swig/_ecp_wrapper.so" "/home/app/"

--- a/src/assignment.cpp
+++ b/src/assignment.cpp
@@ -111,7 +111,15 @@ Node *find_nearest_leaf(DATATYPE *query, vector<Node> &nodes)
  */
 int assign_points_to_cluster(string dataset_file_path, string ecp_dir_path, int num_chunks)
 {
-    vector<Node> index = load_index(ecp_dir_path + "ecp_index.bin"); // Read index from binary file
+    fstream existing_clusters_file(ecp_dir_path + ECP_CLUSTERS_FILE_NAME);
+    if (existing_clusters_file.is_open())
+    {
+        cout << "ECP_ASSIGNMENT: NOT CREATING NEW CLUSTERS, USING EXISTING CLUSTERS FILE FROM " << ecp_dir_path << endl;
+        existing_clusters_file.close();
+        return 0;
+    }
+
+    vector<Node> index = load_index(ecp_dir_path + ECP_INDEX_FILE_NAME); // Read index from binary file
 
     fstream dataset_file;
     dataset_file.open(dataset_file_path, ios::in | ios::binary); // Open given input dataset binary file
@@ -200,7 +208,7 @@ int assign_points_to_cluster(string dataset_file_path, string ecp_dir_path, int 
     vector<ClusterMeta> ecp_cluster_meta_data;      // Meta data describing final database file of cluster assignments
 
     fstream cluster_file;
-    cluster_file.open(ecp_dir_path + "ecp_clusters.bin", ios::out | ios::binary);
+    cluster_file.open(ecp_dir_path + ECP_CLUSTERS_FILE_NAME, ios::out | ios::binary);
 
     for (auto leaf : leafs) // Go through each leaf in index tree
     {
@@ -243,7 +251,7 @@ int assign_points_to_cluster(string dataset_file_path, string ecp_dir_path, int 
 
     uint32_t num_leafs = leafs.size();
     fstream cluster_meta_file;
-    string meta_data_file_path = ecp_dir_path + "ecp_cluster_meta.bin";
+    string meta_data_file_path = ecp_dir_path + ECP_CLUSTER_META_FILE_NAME;
     cluster_meta_file.open(meta_data_file_path, ios::out | ios::binary);
     cluster_meta_file.write(reinterpret_cast<char *>(&num_leafs), sizeof(uint32_t));
 

--- a/src/datastructure.hpp
+++ b/src/datastructure.hpp
@@ -5,6 +5,9 @@
 #include <vector>
 
 #define DATATYPE int8_t
+#define ECP_INDEX_FILE_NAME "ecp_index.bin"
+#define ECP_CLUSTERS_FILE_NAME "ecp_clusters.bin"
+#define ECP_CLUSTER_META_FILE_NAME "ecp_cluster_meta.bin"
 
 namespace globals
 {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -7,6 +7,8 @@
 
 using namespace std;
 
+#define ECP_INDEX_FILE_NAME "ecp_index.bin"
+
 /**
  * Load node from given index binary file into memory
  */
@@ -137,11 +139,20 @@ int create_index(string dataset_file_path, string ecp_dir_path, int L, int desir
     dataset_file.open(dataset_file_path, ios::in | ios::binary); // Open given input dataset binary file
 
     uint32_t num_points = 0;
-    dataset_file.read((char *)&num_points, sizeof(uint32_t));              // Total number of points with n demensions
+    dataset_file.read((char *)&num_points, sizeof(uint32_t));              // Total number of points with n dimensions
     dataset_file.read((char *)&globals::NUM_DIMENSIONS, sizeof(uint32_t)); // Total number of dimensions for one point
 
     auto cur_metric = static_cast<distance::Metric>(metric);
     distance::set_distance_function(cur_metric); // Set distance function globally
+
+    fstream existing_index_file(ecp_dir_path + ECP_INDEX_FILE_NAME);
+    if (existing_index_file.is_open())
+    {
+        cout << "ECP_INDEX: NOT CREATING NEW INDEX, USING EXISTING INDEX FILE FROM " << ecp_dir_path << endl;
+        existing_index_file.close();
+        dataset_file.close();
+        return 0;
+    }
 
     uint32_t num_leaders = ceil(num_points / (desired_cluster_size / (sizeof(DATATYPE) * globals::NUM_DIMENSIONS + sizeof(uint32_t)))); // Calculate overall number of leaders
 
@@ -174,7 +185,7 @@ int create_index(string dataset_file_path, string ecp_dir_path, int L, int desir
     dataset_file.close(); // Close input dataset binary file
 
     uint32_t num_nodes_in_index = 0;
-    string index_file_path = ecp_dir_path + "ecp_index.bin"; // Create path to index binary file
+    string index_file_path = ecp_dir_path + ECP_INDEX_FILE_NAME; // Create path to index binary file
     fstream index_file;
     index_file.open(index_file_path, ios::out | ios::binary);                          // Open index binary file
     index_file.write(reinterpret_cast<char *>(&num_nodes_in_index), sizeof(uint32_t)); // Write placeholder for total number of nodes in index included

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -7,8 +7,6 @@
 
 using namespace std;
 
-#define ECP_INDEX_FILE_NAME "ecp_index.bin"
-
 /**
  * Load node from given index binary file into memory
  */


### PR DESCRIPTION
Check if index or clusters files already existing and use them instead of creating new ones every time.